### PR TITLE
Access logo via `.src` to avoid `ImageMetadata` type issue

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -21,7 +21,7 @@ const { activeNav } = Astro.props;
         {
           LOGO_IMAGE.enable ? (
             <img
-              src={LOGO_IMAGE.svg ? logoSVG : logoPNG}
+              src={LOGO_IMAGE.svg ? logoSVG.src : logoPNG.src}
               alt="AstroPaper Logo"
               width={LOGO_IMAGE.width}
               height={LOGO_IMAGE.height}


### PR DESCRIPTION
While testing your changes from https://github.com/satnaing/astro-paper/pull/112 locally, I encountered this issue: `Type 'ImageMetadata' is not assignable to type 'string'.ts` - Based on the Astro 3.0 changes, it seems that passing the src via `.src` is the intended way to use this now